### PR TITLE
修复点击back键，再次进入时悬浮窗不可见的 Bug

### DIFF
--- a/app/src/main/java/com/huai/gamesdk/widget/GameFloatWindowMgr.java
+++ b/app/src/main/java/com/huai/gamesdk/widget/GameFloatWindowMgr.java
@@ -302,6 +302,8 @@ public class GameFloatWindowMgr {
 		removeBigWindow(context);
 		removeHideWindow(context);
 		removeSmallWindow(context);
+
+		onDestory();
 	}
 
 	/**


### PR DESCRIPTION
作者您好，您的开源项目对我的工作有很大帮助，很感谢你的无私。
在使用 sdk 时，发现在点击 back 按键后退出 Activity 后，悬浮窗就不可见了，点击 “显示浮标” 按钮无效。后来在您的Window 管理类中将 onDestroy 调用一次就修复好了，可能是您在百忙之中，忘记调用了吧。

                                                                                                                               坐标深圳的 Andorid 开发者